### PR TITLE
Remove unused `-include_lib(...`

### DIFF
--- a/src/stdout_formatter_table.erl
+++ b/src/stdout_formatter_table.erl
@@ -9,7 +9,6 @@
 
 -module(stdout_formatter_table).
 
--include_lib("eunit/include/eunit.hrl").
 -include("stdout_formatter.hrl").
 
 -export([format/1,


### PR DESCRIPTION
As it causes `mix compile` to fail with elixir 1.15